### PR TITLE
Create fields from form and support dynamic fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create a field instance:
 const email = createField()
 ```
 
-Options can be passed to define a custom validation (which can be async, and should return a message if invalid or null if valied) and whether to perform validation on input (dirty) or when touched (blur). Validation doesn't run on initial render to prevent failed messages appearing before any user interaction.
+Options can be passed to define a custom validation (which can be async, and should return a message if invalid or null if valied) and whether to perform validation on input or not (`onDirty`, default true). Validation doesn't run on initial render to prevent failed messages appearing before any user interaction.
 
 ```ts
 // is valid if > 5 characters, otherwise invalid, with random 0.5 - 1.5 second delay
@@ -40,10 +40,10 @@ async function isNameAvailable(value: string) {
 	return valid ? null : `Name '${value}' not available`
 }
 
-const name = createField({ validator: isNameAvailable, onDirty: true })
+const name = createField({ validator: isNameAvailable })
 ```
 
-The field instance is applies to an HTML Input Element as a `use:action` (it adds some WIA-ARIA handling):
+The field instance is applied to an HTML Input Element as a `use:action` (it adds some WIA-ARIA handling):
 
 ```svelte
 <input use:name type="text" placeholder="unique name" required />
@@ -94,6 +94,15 @@ A form aggregates the state of the fields - a form is valid if all the fields ar
 
 ```ts
 const form = createForm(email, age, name, random)
+```
+
+Or alternatively, create the form and use the `.field()` method on it to create each field. This avoids the potential issue of the form fields you create and use getting out of sync with the fields you pass to the form.
+
+```ts
+const form = createForm()
+
+const name = form.field({ validator: isNameAvailable })
+const email = form.field()
 ```
 
 Just like the fields, the form instance is applied to the HTML Form Element as a `use:action`

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A form aggregates the state of the fields - a form is valid if all the fields ar
 const form = createForm(email, age, name, random)
 ```
 
-Or alternatively, create the form and use the `.field()` method on it to create each field. This avoids the potential issue of the form fields you create and use getting out of sync with the fields you pass to the form.
+Or alternatively, create the form and use the `.field()` method on it to add a new field. This avoids the potential issue of the form fields you create and use getting out of sync with the fields you pass to the form.
 
 ```ts
 const form = createForm()

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -1,7 +1,7 @@
 import { writable } from 'svelte/store'
 import type { Readable } from 'svelte/store'
 import type { Action } from 'svelte/action'
-import type { Form } from './form'
+import type { FormInternal } from './form'
 
 type Mutable<Type> = {
   -readonly [Key in keyof Type]: Type[Key]
@@ -43,7 +43,7 @@ export interface FieldOptions {
 // Field store & use:action
 export interface Field extends Readable<FieldState>, Action<HTMLInputElement> { }
 
-export function createField(options?: FieldOptions, form?: Form): Field {
+export function createField(options?: FieldOptions, form?: FormInternal): Field {
   const id = newID()
   const { onDirty, validator } = { onDirty: true, ...options }
   const { subscribe, update } = writable<FieldState>({ id, ...defaultFieldState })

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -44,7 +44,7 @@ export interface Field extends Readable<FieldState>, Action<HTMLInputElement> { 
 
 export function createField(options?: FieldOptions): Field {
   const id = newID()
-  const { onDirty, validator } = { onDirty: false, ...options }
+  const { onDirty, validator } = { onDirty: true, ...options }
   const { subscribe, update } = writable<FieldState>({ id, ...defaultFieldState })
 
   const action = (input: HTMLInputElement) => {

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store'
 import type { Readable } from 'svelte/store'
 import type { Action } from 'svelte/action'
+import type { Form } from './form'
 
 type Mutable<Type> = {
   -readonly [Key in keyof Type]: Type[Key]
@@ -42,12 +43,13 @@ export interface FieldOptions {
 // Field store & use:action
 export interface Field extends Readable<FieldState>, Action<HTMLInputElement> { }
 
-export function createField(options?: FieldOptions): Field {
+export function createField(options?: FieldOptions, form?: Form): Field {
   const id = newID()
   const { onDirty, validator } = { onDirty: true, ...options }
   const { subscribe, update } = writable<FieldState>({ id, ...defaultFieldState })
 
   const action = (input: HTMLInputElement) => {
+    form && form.add(field)
     let globalNonce: Object
 
     async function checkValidity(touched = false, dirty = false) {
@@ -110,13 +112,16 @@ export function createField(options?: FieldOptions): Field {
 
     return {
       destroy() {
+        form && form.del(field)
         input.removeEventListener('blur', onBlur)
         input.removeEventListener('input', onInput)
       },
     }
   }
 
-  return Object.assign(action, { subscribe })
+  const field = Object.assign(action, { subscribe })
+
+  return field
 }
 
 function validityToObject(validity: ValidityState) {

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -43,13 +43,17 @@ export interface FieldOptions {
 // Field store & use:action
 export interface Field extends Readable<FieldState>, Action<HTMLInputElement> { }
 
+export interface FieldInternal extends Field {
+  form?: FormInternal
+}
+
 export function createField(options?: FieldOptions, form?: FormInternal): Field {
   const id = newID()
   const { onDirty, validator } = { onDirty: true, ...options }
   const { subscribe, update } = writable<FieldState>({ id, ...defaultFieldState })
 
   const action = (input: HTMLInputElement) => {
-    form && form.add(field)
+    field.form && field.form.add(field)
     let globalNonce: Object
 
     async function checkValidity(touched = false, dirty = false) {
@@ -112,14 +116,14 @@ export function createField(options?: FieldOptions, form?: FormInternal): Field 
 
     return {
       destroy() {
-        form && form.del(field)
+        field.form && field.form.del(field)
         input.removeEventListener('blur', onBlur)
         input.removeEventListener('input', onInput)
       },
     }
   }
 
-  const field = Object.assign(action, { subscribe })
+  const field = Object.assign(action, { subscribe, form })
 
   return field
 }

--- a/src/lib/form.ts
+++ b/src/lib/form.ts
@@ -14,6 +14,9 @@ export interface FormState {
 
 export interface Form extends Readable<FormState>, Action<HTMLFormElement> {
   field(options?: FieldOptions): Field
+}
+
+export interface FormInternal extends Form {
   add(field: Field): void
   del(field: Field): void
 }
@@ -81,7 +84,7 @@ export function createForm(...fields: Field[]): Form {
     unsubscribe = createAggregator(fields, unsubscribe)
   }
 
-  const form = Object.assign(action, { subscribe, field, add, del })
+  const form: FormInternal = Object.assign(action, { subscribe, field, add, del })
 
   return form
 }

--- a/src/lib/form.ts
+++ b/src/lib/form.ts
@@ -2,7 +2,7 @@ import { derived, writable } from 'svelte/store'
 import type { Readable, Unsubscriber } from 'svelte/store'
 import type { Action } from 'svelte/action'
 import { createField } from './field'
-import type { Field, FieldOptions } from './field'
+import type { Field, FieldOptions, FieldInternal } from './field'
 
 export interface FormState {
   dirty: boolean
@@ -85,6 +85,8 @@ export function createForm(...fields: Field[]): Form {
   }
 
   const form: FormInternal = Object.assign(action, { subscribe, field, add, del })
+
+  fields.forEach(f => (f as FieldInternal).form = form)
 
   return form
 }

--- a/src/routes/form/+page.svelte
+++ b/src/routes/form/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createField, createForm } from '$lib'
+	import { createForm } from '$lib'
 
 	// is valid if > 5 characters, otherwise invalid, with random 0.5 - 1.5 second delay
 	async function isNameAvailable(value: string) {
@@ -8,14 +8,12 @@
 		return valid ? null : `Name '${value}' not available`
 	}
 
-	const email = createField()
-	const age = createField()
-	const name = createField({ validator: isNameAvailable, onDirty: true })
-	const random = createField()
-	const radio = createField({ onDirty: true })
-
-	// TODO: try to remove the need to populate the form with the fields by keeping track as they are added to the DOM
-	const form = createForm(email, age, name, random, radio)
+	const form = createForm()
+	const email = form.field()
+	const age = form.field()
+	const name = form.field({ validator: isNameAvailable })
+	const random = form.field()
+	const radio = form.field()
 
 	function onSubmit() {
 		// whatever

--- a/src/routes/form/+page.svelte
+++ b/src/routes/form/+page.svelte
@@ -15,6 +15,8 @@
 	const random = form.field()
 	const radio = form.field()
 
+	let showEmail = true
+
 	function onSubmit() {
 		// whatever
 	}
@@ -30,12 +32,18 @@
 		{#if $name.customError}Name not available{/if}
 	</div>
 
-	<label for="email" class="mt-2 text-sm text-gray-500">Email</label>
-	<input id="email" use:email type="email" placeholder="email address" required />
-	<div id={$email.id} class="m-1 text-xs text-red-700" hidden={!$email.show}>
-		{#if $email.valueMissing}Email address is required{/if}
-		{#if $email.typeMismatch}Not a valid email address{/if}
-	</div>
+	<label class="flex items-center">
+		<input class="mr-2" type="checkbox" bind:checked={showEmail} />
+		Include Email in Form
+	</label>
+	{#if showEmail}
+		<label for="email" class="mt-2 text-sm text-gray-500">Email</label>
+		<input id="email" use:email type="email" placeholder="email address" required />
+		<div id={$email.id} class="m-1 text-xs text-red-700" hidden={!$email.show}>
+			{#if $email.valueMissing}Email address is required{/if}
+			{#if $email.typeMismatch}Not a valid email address{/if}
+		</div>
+	{/if}
 
 	<label for="age" class="mt-2 text-sm text-gray-500">Age</label>
 	<input id="age" use:age type="number" required value="0" min="18" max="65" />


### PR DESCRIPTION
Avoids potential mismatch from passing fields into the form constructor (i.e. adding a field requires changes in two place)

```ts
const form = createForm()
const email = form.field()
```

The current constructor is still there for the time being but will likely be removed along with the option to create a field that _isn't_ associated with a form (i.e.`createField()`)

Also adds support for dynamic fields - only fields with HTML Input elements in the DOM contribute to the form validity state. So if the input of an email can be toggled, it won't prevent the form being submitted, but can require validation if present.